### PR TITLE
fix: skip recipient id in to_bytes for tx type 1 and 4 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.1.1
+
+### Fixed
+- Skip recipient id in `to_bytes` for type 1 and 4 transactions.
+
 ## 0.1.0 - 2018-09-03
 - Initial Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "arkecosystem-crypto"
 version = "0.1.0"
-authors = ["Joshua Noack"]
+authors = ["Joshua Noack <joshua@ark.io>"]
 description = "A simple Cryptography Implementation in Rust for the ARK Blockchain."
 license = "MIT"
 

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -127,7 +127,8 @@ impl Transaction {
 
         buffer.extend_from_slice(&hex::decode(&self.sender_public_key).unwrap());
 
-        let recipient_id = if self.recipient_id.len() > 0 {
+        let skip_recipient_id = self.type_id == TransactionType::SecondSignatureRegistration || self.type_id == TransactionType::MultiSignatureRegistration;
+        let recipient_id = if self.recipient_id.len() > 0 && !skip_recipient_id {
             base58::from_check(&self.recipient_id).unwrap()
         } else {
             iter::repeat(0).take(21).collect()

--- a/tests/transactions/deserializer/delegate_registration_test.rs
+++ b/tests/transactions/deserializer/delegate_registration_test.rs
@@ -35,6 +35,7 @@ fn test_signed_with_a_passphrase() {
         fixture["data"]["signature"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 
     let asset = fixture["data"]["asset"].clone();
     assert_eq!(transaction.asset, serde_json::from_value(asset).unwrap());
@@ -76,6 +77,7 @@ fn test_signed_with_a_second_passphrase() {
         fixture["data"]["signSignature"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 
     let asset = fixture["data"]["asset"].clone();
     assert_eq!(transaction.asset, serde_json::from_value(asset).unwrap());

--- a/tests/transactions/deserializer/multi_signature_registration_test.rs
+++ b/tests/transactions/deserializer/multi_signature_registration_test.rs
@@ -46,6 +46,7 @@ fn test_signed_with_a_passphrase() {
         serde_json::from_value::<Vec<String>>(fixture["data"]["signatures"].clone()).unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 
     let asset = fixture["data"]["asset"].clone();
     assert_eq!(transaction.asset, serde_json::from_value(asset).unwrap());

--- a/tests/transactions/deserializer/second_signature_registration_test.rs
+++ b/tests/transactions/deserializer/second_signature_registration_test.rs
@@ -43,6 +43,7 @@ fn test_signed_with_a_second_passphrase() {
         fixture["data"]["signature"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 
     let asset = fixture["data"]["asset"].clone();
     assert_eq!(transaction.asset, serde_json::from_value(asset).unwrap());

--- a/tests/transactions/deserializer/transfer_test.rs
+++ b/tests/transactions/deserializer/transfer_test.rs
@@ -39,6 +39,7 @@ fn test_signed_with_a_passphrase() {
         fixture["data"]["signature"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 }
 
 #[test]
@@ -82,6 +83,7 @@ fn test_signed_with_a_second_passphrase() {
         fixture["data"]["signSignature"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 }
 
 #[test]
@@ -124,6 +126,7 @@ fn test_signed_with_a_passphrase_and_vendor_field() {
         fixture["data"]["vendorField"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 }
 
 #[test]
@@ -170,6 +173,7 @@ fn test_signed_with_a_second_passphrase_and_vendor_field() {
         fixture["data"]["vendorField"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 }
 
 #[test]
@@ -212,6 +216,7 @@ fn test_signed_with_a_passphrase_and_vendor_hex_field() {
         fixture["data"]["vendorFieldHex"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 }
 
 #[test]
@@ -258,4 +263,5 @@ fn test_signed_with_a_second_passphrase_and_vendor_hex_field() {
         fixture["data"]["vendorFieldHex"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 }

--- a/tests/transactions/deserializer/vote_test.rs
+++ b/tests/transactions/deserializer/vote_test.rs
@@ -39,6 +39,7 @@ fn test_signed_with_a_passphrase() {
         fixture["data"]["recipientId"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 
     let asset = fixture["data"]["asset"].clone();
     assert_eq!(transaction.asset, serde_json::from_value(asset).unwrap());
@@ -84,6 +85,7 @@ fn test_signed_with_a_second_passphrase() {
         fixture["data"]["recipientId"].as_str().unwrap()
     );
     assert_eq!(transaction.id, fixture["data"]["id"].as_str().unwrap());
+    assert_eq!(transaction.verify(), true);
 
     let asset = fixture["data"]["asset"].clone();
     assert_eq!(transaction.asset, serde_json::from_value(asset).unwrap());


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In second signature and multi signature transactions the recipient id is not supposed to be included in the signature/id calculation. Add an additional check to `to_bytes` to explicitely exclude the recipientId. This also allows such transactions to be verified, even if the recipientId is set.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
<!--