### PR TITLE
docs: fix documentation sdk url

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Documentation
 
-You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/api/sdk/cryptography/rust.html).
+You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/sdk/cryptography/rust.html).
 
 ## Security
 


### PR DESCRIPTION
## Proposed changes

`/api/sdk` was changed to `/sdk`, this PR fixes the URL.

## Types of changes

- [x] Docs (documentation only changes)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're re here to help! This is simply a reminder of what we are going to look for before merging your code._
-->

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/guidebook/contribution-guidelines/contributing.html) documentation
- [x] I have read the [WRITING DOCUMENTATION](https://docs.ark.io/guidebook/contribution-guidelines/writing-documentation.html) guidelines
